### PR TITLE
The error event should be triggered by a timeout

### DIFF
--- a/react-cardknox-ifields/src/iField.js
+++ b/react-cardknox-ifields/src/iField.js
@@ -135,6 +135,7 @@ export default class IField extends React.Component {
      * @param {{data: TokenData}} param0 
      */
     onToken({ data }) {
+        clearTimeout(this.state.timeoutcallback)
         if (data.result === ERROR) {
             this.log("Token Error: " + data.errorMessage);
             if (this.props.onError)
@@ -209,12 +210,20 @@ export default class IField extends React.Component {
         this.logAction(INIT);
         this.postMessage(message);
     }
-    getToken() {
+        getToken() {
         var message = {
             action: GET_TOKEN
-        };
+        };        
         this.logAction(GET_TOKEN);
         this.postMessage(message);
+        this.setState({timeoutcallback: setTimeout(() => {
+            this.onToken({
+                data: {
+                    result: ERROR,
+                    errorMessage: "Transaction timed out."
+                }
+            })
+        }, 60000)});
     }
     /**
      * 


### PR DESCRIPTION
The goal here is to avoid leaving the request unanswered when there's no internet connection (or the request fails for another reason).